### PR TITLE
import experimental pragma to enable smartmatch

### DIFF
--- a/gff3sort.pl
+++ b/gff3sort.pl
@@ -10,6 +10,7 @@ use lib "$Bin";
 use Sort::Naturally qw/nsort/;    ###### https://metacpan.org/pod/Sort::Naturally
 use Sort::Topological qw/toposort/;   ###### https://metacpan.org/pod/Sort::Topological
 use Pod::Usage;
+use experimental qw/smartmatch/;
 
 ############ Usage ############
 my $help;


### PR DESCRIPTION
Using smartmatch (i.e,. "~~") will throw warnings with modern Perl versions unless explicitly enabled through the "experimental" pragma. For reference, see: https://metacpan.org/pod/experimental